### PR TITLE
5/Add aranya product diagram

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,8 +36,4 @@
             ga('send', 'pageview');
         </script>
     {% endif %}
-
-    {% if page.mermaid %}
-        {% include mermaid.html %}
-    {% endif %}
 </head>

--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -1,3 +1,0 @@
-<script type="text/javascript"
-  src="https://unpkg.com/mermaid@11.4.1/dist/mermaid.min.js">
-</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,5 +25,8 @@
         </div>
         <div for="sidebar-checkbox" class="sidebar-toggle"></div>
         <script src='{{ site.url }}/public/js/script.js'></script>
+        {% if page.mermaid %}
+        <script type="module" src='{{ site.url }}/public/js/mermaid.js'></script>
+        {% endif %}
     </body>
 </html>

--- a/docs/aranya-archetecture.md
+++ b/docs/aranya-archetecture.md
@@ -2,41 +2,13 @@
 layout: page
 title: Aranya Architecture
 permalink: "/aranya-architecture/"
+mermaid: true
 ---
 
 # Aranya Architecture
 
-```mermaid
+<div class="mermaid">
 flowchart-elk TB
- subgraph ClientLibrary["Client Library"]
-        a1("User Application")
-        a2("C-API")
-        a3("Rust API")
-        a4("UDS Client")
-        a5("AFC Router")
-        a6("AFC")
-  end
- subgraph UserProcess["User Process"]
-        ClientLibrary
-  end
- subgraph PeerUserProcess["Peer User Process"]
-        b1("AFC Router")
-  end
- subgraph Daemon["Daemon"]
-        c1("UDS API")
-        c2("Aranya")
-        c3("Policy")
-        c4("shm")
-        c5("Sync")
-        c6("Storage")
-  end
- subgraph PeerDaemon["Peer Daemon"]
-        e1("Sync")
-  end
- subgraph DaemonConfig["Daemon Config"]
-        d1("UDS Path")
-        d2("Working Directory")
-  end
     a1 --> a2
     a2 --> a3
     a3 --> a4 & a5
@@ -50,4 +22,34 @@ flowchart-elk TB
     Daemon --> DaemonConfig
     a5 -- AFC Ctr/Data <br> TCP Transport --> b1
     c5 -- Aranya Sync <br> TCP Transport --> e1
-```
+    subgraph ClientLibrary["Client Library"]
+            a1("User Application")
+            a2("C-API")
+            a3("Rust API")
+            a4("UDS Client")
+            a5("AFC Router")
+            a6("AFC")
+    end
+    subgraph UserProcess["User Process"]
+            ClientLibrary
+    end
+    subgraph PeerUserProcess["Peer User Process"]
+            b1("AFC Router")
+    end
+    subgraph Daemon["Daemon"]
+            c1("UDS API")
+            c2("Aranya")
+            c3("Policy")
+            c4("shm")
+            c5("Sync")
+            c6("Storage")
+    end
+    subgraph PeerDaemon["Peer Daemon"]
+            e1("Sync")
+    end
+    subgraph DaemonConfig["Daemon Config"]
+            d1("UDS Path")
+            d2("Working Directory")
+    end
+</div>
+

--- a/docs/aranya-archetecture.md
+++ b/docs/aranya-archetecture.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: Aranya Architecture
+permalink: "/aranya-architecture/"
+---
+
+# Aranya Architecture
+
+```mermaid
+flowchart-elk TB
+ subgraph ClientLibrary["Client Library"]
+        a1("User Application")
+        a2("C-API")
+        a3("Rust API")
+        a4("UDS Client")
+        a5("AFC Router")
+        a6("AFC")
+  end
+ subgraph UserProcess["User Process"]
+        ClientLibrary
+  end
+ subgraph PeerUserProcess["Peer User Process"]
+        b1("AFC Router")
+  end
+ subgraph Daemon["Daemon"]
+        c1("UDS API")
+        c2("Aranya")
+        c3("Policy")
+        c4("shm")
+        c5("Sync")
+        c6("Storage")
+  end
+ subgraph PeerDaemon["Peer Daemon"]
+        e1("Sync")
+  end
+ subgraph DaemonConfig["Daemon Config"]
+        d1("UDS Path")
+        d2("Working Directory")
+  end
+    a1 --> a2
+    a2 --> a3
+    a3 --> a4 & a5
+    a5 --> a6
+    a4 -- UDS --> c1
+    c1 --> c2
+    c2 --> c3
+    a6 -- shm --> c4
+    c4 --> c5
+    c5 --> c6
+    Daemon --> DaemonConfig
+    a5 -- AFC Ctr/Data <br> TCP Transport --> b1
+    c5 -- Aranya Sync <br> TCP Transport --> e1
+```

--- a/docs/aranya-overview.md
+++ b/docs/aranya-overview.md
@@ -2,7 +2,6 @@
 layout: page
 title: Overview
 permalink: "/overview/"
-tags: [Mermaid]
 mermaid: true
 ---
 
@@ -231,7 +230,7 @@ Policy evaluation in Aranya relies on the set of facts stored in the fact databa
 
 To call an Action, the entity will follow the following process:
 
-<div class="mermaid mermaid-wrapper">
+<div class="mermaid">
 flowchart TB
     A(Entity) -- Calls an action --> B(Action) -- Action issues Command --> C(Command) -- Command is evaluated by the policy --> D(Policy)
     D -- Command is accepted --> E(Accepted)
@@ -245,7 +244,7 @@ _Figure 3: Calling an Action Workflow_
 
 To sync with a peer or other entity using Aranya, the entity will follow the following process:
 
-<div class="mermaid mermaid-wrapper">
+<div class="mermaid">
 flowchart TB
     I(Entity) -- Sync with peer --> J(Sync)
     J -- Sync sends new command --> K(Peer)

--- a/docs/model.md
+++ b/docs/model.md
@@ -2,7 +2,6 @@
 layout: page
 title: Aranya Model
 permalink: "/aranya-model/"
-tags: [Mermaid]
 mermaid: true
 ---
 
@@ -19,7 +18,7 @@ The APIs use simple user generated segregate Proxy IDs for the public client and
 ## Client State
 Each client in the model can be thought of as an instance of Aranya Client State or the state of its graph. To configure an Aranya client, we need to look at its component parts.
 
-<div class="mermaid mermaid-wrapper">
+<div class="mermaid">
     flowchart
         A(Policy Document) --> B(Policy Parser)
         B --> C(Policy Compiler)
@@ -80,7 +79,7 @@ The client state keeps track of the state of the graph in the runtime client. Th
 
 
 ## Model Client
-<div class="mermaid mermaid-wrapper">
+<div class="mermaid">
     flowchart
         A(Client State) --> B(Model Client)
         C(Public Keys) --> B
@@ -92,7 +91,7 @@ Once we have the required configurations to build the client state, we can const
 When key bundles are created, they are limited in scope to the factory in which they are instantiated. We need to use the public key portion of the bundle to interact with various parts of the policy. Because of this we store them as part of the model client.
 
 ## Runtime Model
-<div class="mermaid mermaid-wrapper">
+<div class="mermaid">
     flowchart
         A(clients) --> B(RuntimeModel)
         C(storage_ids) --> B

--- a/public/css/spideroak.css
+++ b/public/css/spideroak.css
@@ -78,10 +78,18 @@
         margin-bottom: 1.5rem;
     }
 }
+
+/* Hide raw Mermaid code to stop flash of unstyled content */
+.mermaid {
+    height: 0;
+    margin-bottom: 1rem;
+    overflow: hidden;
+}
+.mermaid.processed {
+    height: auto;
+    overflow: unset;
+}
 .mermaid svg {
     margin: 0 auto;
     display: block;
-}
-.mermaid-wrapper {
-    margin-bottom: 1rem;
 }

--- a/public/js/mermaid.js
+++ b/public/js/mermaid.js
@@ -1,0 +1,38 @@
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+import elkLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0.1.7/dist/mermaid-layout-elk.esm.min.mjs";
+
+const diagrams = document.querySelectorAll(".mermaid");
+
+// Callback to show Mermaid diagram once it's been processed.
+// We hide the raw Mermaid code to stop flash of unstyled content.
+const mutationCallback = (mutationsList) => {
+    for (const mutation of mutationsList) {
+        if (
+            mutation.type !== "attributes" ||
+            mutation.attributeName !== "data-processed"
+        ) {
+            return;
+        }
+
+        // Check if diagram has been processed.
+        if (mutation.target.getAttribute("data-processed") === "true") {
+            // Add class to show it.
+            mutation.target.classList.add("processed");
+        }
+    }
+};
+
+const observer = new MutationObserver(mutationCallback);
+
+// Observe all Mermaid diagrams
+for (const diagram of diagrams) {
+    observer.observe(diagram, { attributes: true });
+}
+
+// Render mermaid diagrams
+mermaid.registerLayoutLoaders(elkLayouts);
+
+// Remove observer on page exit
+window.addEventListener("beforeunload", () => {
+    observer.disconnect();
+});


### PR DESCRIPTION
This PR adds the Aranya architecture diagram as a Mermaid JS code block. It also adds support for the `elk` layout engine which will make some of the more complex diagrams more readable. 

See https://aranya-project.github.io/aranya-docs/aranya-architecture/ for the deployed page. Currently the Mermaid rendering for this diagram isn't a quick as I'd like, however once cached it's not bad. We'll want to improve that in the future. 

Closes https://github.com/aranya-project/aranya-docs/issues/5

~~The downside to this is, Mermaid is limiting in the way it automatically flows the nodes. We can make some improvements by using the alternate layout engine `elk`. However that is not available in the default GH Markdown engine that GH uses to render this in the repo. We can however install elk in the published GH Pages docs using the `@mermaid-js/layout-elk` npm package.  But that wouldn't do anything for the vanilla rendering of the diagram in the repo, only the deployed Jekyll site.~~

