### PR TITLE
capi: link to aranya capi docs

### DIFF
--- a/docs/capi.md
+++ b/docs/capi.md
@@ -18,10 +18,8 @@ The API includes methods for the following types of operations:
 
 ## Doxygen Docs
 
-The C API docs are generated with Doxygen and hosted on GitHub pages.
-
+The [Aranya C API](https://github.com/aranya-project/aranya/tree/main/crates/aranya-client-capi) docs are generated with [Doxygen](https://github.com/aranya-project/aranya/blob/main/crates/aranya-client-capi/Doxyfile) and hosted on GitHub pages:
 <!-- TODO: generate directory tree automatically -->
-C API Docs:
 {% assign capi_url = 'https://aranya-project.github.io/aranya/capi' %}
 <ul>
     <li><a href="{{ capi_url }}/v0.4.0">latest</a></li>
@@ -30,36 +28,12 @@ C API Docs:
     <li><a href="{{ capi_url }}/v0.2.0">v0.2.0</a></li>
 </ul>
 
-Doxygen docs are uploaded to each Aranya release here:
-[Aranya releases](https://github.com/aranya-project/aranya/releases)
+The docs are uploaded to each Aranya [release](https://github.com/aranya-project/aranya/releases) and can be generated locally by running `cargo make build-capi-docs` in the [aranya](https://github.com/aranya-project/aranya) repo.
 
-Doxgygen docs can be manually generated from source by running this `cargo make` task in the [aranya](https://github.com/aranya-project/aranya) repo:
-```
-cargo make build-capi-docs
-```
+## Example Application
 
-## Example Application Using The Aranya C API
+There is an [example application](https://github.com/aranya-project/aranya/tree/main/examples/c) which includes the [header file](https://github.com/aranya-project/aranya/blob/main/crates/aranya-client-capi/output/aranya-client.h) and builds the library into the application with `cmake`. A [CMakeLists.txt](https://github.com/aranya-project/aranya/blob/main/examples/c/CMakeLists.txt) is provided to make it easier to build the library into an application.
 
-An example application for interacting with Aranya via the C API is provided here:
-[Aranya C Example](https://github.com/aranya-project/aranya/tree/main/examples/c)
+Pre-built versions of the library are uploaded (along with the [header file](https://github.com/aranya-project/aranya/blob/main/crates/aranya-client-capi/output/aranya-client.h)) to each Aranya [release](https://github.com/aranya-project/aranya/releases).
 
-To run the example C application, execute this `cargo make` task in the [aranya](https://github.com/aranya-project/aranya) repo:
-```
-cargo make run-capi-example
-```
-
-## Integrating The C API Into A C Application
-
-In order to integrate the C library into an application, include the [aranya-client.h](https://github.com/aranya-project/aranya/blob/main/crates/aranya-client-capi/output/aranya-client.h) header file and compile the application with the Aranya client library.
-
-Pre-built versions of the library are uploaded (along with the C header) to Aranya releases here:
-[Aranya releases](https://github.com/aranya-project/aranya/releases)
-
-The library can be built from source by running the following `cargo make` command in the [aranya](https://github.com/aranya-project/aranya) repo:
-```
-cargo make build-capi
-```
-
-A [CMakeLists.txt](https://github.com/aranya-project/aranya/blob/main/examples/c/CMakeLists.txt) is provided to make it easier to build the C library into an application using `cmake`.
-
-It is recommended to start with the [Aranya C Example](https://github.com/aranya-project/aranya/tree/main/examples/c) and modify it into another application rather than attempting to build an application from scratch using the C API documentation. 
+After running the example, the locally built library can be found in the `target/release` folder of the [aranya](https://github.com/aranya-project/aranya) repo.

--- a/docs/capi.md
+++ b/docs/capi.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Aranya Client C API
-permalink: "/"
+permalink: "/capi/"
 ---
 
 # Aranya Client C API
@@ -22,7 +22,7 @@ The C API docs are generated with Doxygen and hosted on GitHub pages.
 
 <!-- TODO: generate directory tree automatically -->
 C API Docs:
-{% assign capi_url = https://aranya-project.github.io/aranya/capi %}
+{% assign capi_url = 'https://aranya-project.github.io/aranya/capi' %}
 <ul>
     <li><a href="{{ capi_url }}/v0.4.0">latest</a></li>
     <li><a href="{{ capi_url }}/v0.4.0">v0.4.0</a></li>
@@ -34,7 +34,9 @@ Doxygen docs are uploaded to each Aranya release here:
 [Aranya releases](https://github.com/aranya-project/aranya/releases)
 
 Doxgygen docs can be manually generated from source by running this `cargo make` task in the [aranya](https://github.com/aranya-project/aranya) repo:
-`cargo make build-capi-docs`
+```
+cargo make build-capi-docs
+```
 
 # Example Application Using The Aranya C API
 
@@ -42,7 +44,9 @@ An example application for interacting with Aranya via the C API is provided her
 [Aranya C Example](https://github.com/aranya-project/aranya/tree/main/examples/c)
 
 To run the example C application, execute this `cargo make` task in the [aranya](https://github.com/aranya-project/aranya) repo:
-`cargo make run-capi-example`
+```
+cargo make run-capi-example
+```
 
 # Integrating The C API Into A C Application
 
@@ -52,7 +56,9 @@ Pre-built versions of the library are uploaded (along with the C header) to Aran
 [Aranya releases](https://github.com/aranya-project/aranya/releases)
 
 The library can be built from source by running the following `cargo make` command in the [aranya](https://github.com/aranya-project/aranya) repo:
-`cargo make build-capi`
+```
+cargo make build-capi
+```
 
 A [CMakeLists.txt](https://github.com/aranya-project/aranya/blob/main/examples/c/CMakeLists.txt) is provided to make it easier to build the C library into an application using `cmake`.
 

--- a/docs/capi.md
+++ b/docs/capi.md
@@ -16,7 +16,7 @@ The API includes methods for the following types of operations:
 - Create encrypted AFC channels
 - Send encrypted data via AFC channels
 
-# Doxygen Docs
+## Doxygen Docs
 
 The C API docs are generated with Doxygen and hosted on GitHub pages.
 
@@ -38,7 +38,7 @@ Doxgygen docs can be manually generated from source by running this `cargo make`
 cargo make build-capi-docs
 ```
 
-# Example Application Using The Aranya C API
+## Example Application Using The Aranya C API
 
 An example application for interacting with Aranya via the C API is provided here:
 [Aranya C Example](https://github.com/aranya-project/aranya/tree/main/examples/c)
@@ -48,7 +48,7 @@ To run the example C application, execute this `cargo make` task in the [aranya]
 cargo make run-capi-example
 ```
 
-# Integrating The C API Into A C Application
+## Integrating The C API Into A C Application
 
 In order to integrate the C library into an application, include the [aranya-client.h](https://github.com/aranya-project/aranya/blob/main/crates/aranya-client-capi/output/aranya-client.h) header file and compile the application with the Aranya client library.
 

--- a/docs/capi.md
+++ b/docs/capi.md
@@ -1,0 +1,59 @@
+---
+layout: page
+title: Aranya Client C API
+permalink: "/"
+---
+
+# Aranya Client C API
+
+The Aranya Client provides a C API to allow an application to interact with it.
+
+The API includes methods for the following types of operations:
+- Create a new Aranya team with unique cryptographic identities
+- Add/remove users on a team
+- Assign roles to users based on a policy
+- Configure peers to sync with so the Aranya DAG stays up-to-date
+- Create encrypted AFC channels
+- Send encrypted data via AFC channels
+
+# Doxygen Docs
+
+The C API docs are generated with Doxygen and hosted on GitHub pages.
+
+<!-- TODO: generate directory tree automatically -->
+C API Docs:
+{% assign capi_url = https://aranya-project.github.io/aranya/capi %}
+<ul>
+    <li><a href="{{ capi_url }}/v0.4.0">latest</a></li>
+    <li><a href="{{ capi_url }}/v0.4.0">v0.4.0</a></li>
+    <li><a href="{{ capi_url }}/v0.3.0">v0.3.0</a></li>
+    <li><a href="{{ capi_url }}/v0.2.0">v0.2.0</a></li>
+</ul>
+
+Doxygen docs are uploaded to each Aranya release here:
+[Aranya releases](https://github.com/aranya-project/aranya/releases)
+
+Doxgygen docs can be manually generated from source by running this `cargo make` task in the [aranya](https://github.com/aranya-project/aranya) repo:
+`cargo make build-capi-docs`
+
+# Example Application Using The Aranya C API
+
+An example application for interacting with Aranya via the C API is provided here:
+[Aranya C Example](https://github.com/aranya-project/aranya/tree/main/examples/c)
+
+To run the example C application, execute this `cargo make` task in the [aranya](https://github.com/aranya-project/aranya) repo:
+`cargo make run-capi-example`
+
+# Integrating The C API Into A C Application
+
+In order to integrate the C library into an application, include the [aranya-client.h](https://github.com/aranya-project/aranya/blob/main/crates/aranya-client-capi/output/aranya-client.h) header file and compile the application with the Aranya client library.
+
+Pre-built versions of the library are uploaded (along with the C header) to Aranya releases here:
+[Aranya releases](https://github.com/aranya-project/aranya/releases)
+
+The library can be built from source by running the following `cargo make` command in the [aranya](https://github.com/aranya-project/aranya) repo:
+`cargo make build-capi`
+
+A [CMakeLists.txt](https://github.com/aranya-project/aranya/blob/main/examples/c/CMakeLists.txt) is provided to make it easier to build the C library into an application using `cmake`.
+
+It is recommended to start with the [Aranya C Example](https://github.com/aranya-project/aranya/tree/main/examples/c) and modify it into another application rather than attempting to build an application from scratch using the C API documentation. 

--- a/docs/capi.md
+++ b/docs/capi.md
@@ -28,7 +28,7 @@ The [Aranya C API](https://github.com/aranya-project/aranya/tree/main/crates/ara
     <li><a href="{{ capi_url }}/v0.2.0">v0.2.0</a></li>
 </ul>
 
-The docs are uploaded to each Aranya [release](https://github.com/aranya-project/aranya/releases) and can be generated locally by running `cargo make build-capi-docs` in the [aranya](https://github.com/aranya-project/aranya) repo.
+The docs are uploaded to each Aranya [release](https://github.com/aranya-project/aranya/releases) and can be generated locally by running `cargo make build-capi-docs` in a local clone of the [aranya](https://github.com/aranya-project/aranya) repo.
 
 ## Example Application
 
@@ -36,4 +36,4 @@ There is an [example application](https://github.com/aranya-project/aranya/tree/
 
 Pre-built versions of the library are uploaded (along with the [header file](https://github.com/aranya-project/aranya/blob/main/crates/aranya-client-capi/output/aranya-client.h)) to each Aranya [release](https://github.com/aranya-project/aranya/releases).
 
-After running the example, the locally built library can be found in the `target/release` folder of the [aranya](https://github.com/aranya-project/aranya) repo.
+After running the example, the locally built library can be found in the `target/release` folder of the locally cloned [aranya](https://github.com/aranya-project/aranya) repo.


### PR DESCRIPTION
Create a landing page to link to each version of the Doxygen C API docs.