### PR TITLE
Add baseurl back

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ tagline: 'An overview of the Aranya project'
 description: 'Aranya is an access governance and secure data exchange platform for organizations to control their critical data and services.'
 url: https://aranya-project.github.io/aranya-docs
 project-repo: https://github.com/aranya-project/aranya
+baseurl: ''
 
 collections_dir: pages
 collections:


### PR DESCRIPTION
This PR adds the baseurl config variable back in. It's needed for the Jekyll `absolute_url` shortcut.  

I deployed this branch to test https://aranya-project.github.io/aranya-docs/, it works now. 