### PR TITLE
Add absolute_url helper to menu

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -42,7 +42,7 @@
                             <div>
                                 {% for node in site[collection.label] %}
                                 <li class="sidebar-nav-item">
-                                    <a class="{% if page.url == node.url %}active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
+                                    <a class="{% if page.url == node.url %}active{% endif %}" href="{{ node.url | absolute_url }}">{{ node.title }}</a>
                                 </li>
                                 {% endfor %}
                             </div>


### PR DESCRIPTION
Missed this one in the menu to link to the correct sub-directory. 

Deployed at https://aranya-project.github.io/aranya-docs/