### PR TITLE
Add initial "Core Concepts" section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,9 @@ collections:
     core-concepts:
         menu-order: 01
         menu-name: Core Concepts
-        output: false
+        output: true
         order:
-        - terminology.md
+        - introduction.md
         - architecture.md
         - graph.md
         - access-management.md

--- a/pages/_core-concepts/_terminology.md
+++ b/pages/_core-concepts/_terminology.md
@@ -1,9 +1,0 @@
----
-layout: page
-title: Terminology
----
-
-# Terminology
-
-## Section
-Lorem ipsum odor amet, consectetuer adipiscing elit. Maximus consequat cubilia at quis ultrices. Enim lacinia neque aliquam taciti elit. Tempus netus fusce lacinia, curae venenatis erat. Mollis nisl consectetur inceptos per nam aenean parturient elementum facilisi. Hac justo netus consectetur vitae fermentum maximus feugiat faucibus. Fermentum inceptos magnis elementum gravida mus est senectus. Senectus class molestie at vulputate ipsum nullam eleifend viverra. Proin vulputate egestas luctus felis, amet orci. Vel sagittis ridiculus mi at lorem interdum.

--- a/pages/_core-concepts/introduction.md
+++ b/pages/_core-concepts/introduction.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Introduction
+---
+
+Aranya is useful anywhere you have data that needs to be reconciled, sent
+securely, or restricted. Possible uses could be sending data between IoT
+devices, files or messages between users, encryption keys between computer
+systems or information between embedded devices. All of this capability is
+provided by the open-source [Aranya project](https://github.com/aranya-project),
+written in [Rust](https://www.rust-lang.org/). We provide a
+[client library](https://github.com/aranya-project/aranya/tree/main/crates/aranya-client)
+for integrating with larger applications and a
+[daemon](https://github.com/aranya-project/aranya/tree/main/crates/aranya-daemon)
+that operates over the
+[core functionality](https://github.com/aranya-project/aranya-core).
+
+To test out Aranya for yourself, see the
+[walkthrough]({{ 'getting-started/walkthrough/' | relative_url }}).
+Otherwise, continue reading for more details on the inner workings of Aranya.
+
+## Terminology
+
+The following terms will be used throughout the documentation to describe
+Aranya deployments on **endpoints.** These deployments, or **instances,** are
+further defined as specific **entities,** or devices, once the instance is
+assigned a specific set of cryptographic keys used for identity and
+authentication and are governed by written **policy**.
+
+**Endpoint:** A piece of hardware (e.g. IoT device, computer, cellular phone,
+etc.) or software (e.g. application) on which Aranya is integrated.
+
+**Instance:** A single deployment of the Aranya software. To note, each
+endpoint can have one or many instances deployed on it.
+
+**Entity:** You can think of this as a specific device identity and it is used
+to identify an instance by assigning it a set of cryptographic keys used for
+identity and authentication, allowing it to govern the behavior of the
+endpoint.
+
+**Policy:** Defines specific behaviors, or accepted actions with corresponding
+commands, that will be generated and executed on the endpoint.
+
+For information on more terms commonly used throughout Aranya and our
+documentation, see the [glossary]({{ 'glossary/glossary' | relative_url }}).


### PR DESCRIPTION
This adds a Core Concepts section to the sidebar and an initial "Introduction" document for the section. 

Closes #58. 