### PR TITLE
Remove strict subset check for subselection

### DIFF
--- a/docs/policy-v2.md
+++ b/docs/policy-v2.md
@@ -237,7 +237,7 @@ cannot overlap.
 
 ### Struct Subselection
 
-A struct `A` whose fields are a strict subset of the fields of struct
+A struct `A` whose fields are a subset of the fields of struct
 `B` can be assigned from struct `B` with the struct subselection
 operator `substruct`.
 


### PR DESCRIPTION
Based on the discussion in this [PR thread](https://github.com/aranya-project/aranya-core/pull/120#discussion_r2014987127), subselection doesn't require that the type on the RHS is a strict subset of the struct expression on the LHS