### PR TITLE
Update AFC crypto specification to match implementation

### DIFF
--- a/docs/afc-crypto.md
+++ b/docs/afc-crypto.md
@@ -93,16 +93,15 @@ fn NewChannelKeys(us, peer, parent_cmd_id, label) {
         raise SameIdError
     }
 
-    suite_id = concat(aead_id, kdf_id, signer_id, ...)
     info = concat(
-        "AfcChannelKeys",
-        suite_id,
-        engine_id,
+        "AfcBidiKeys-v1",
         parent_cmd_id,
+        DeviceId(peer),
         DeviceId(us),
-        DeviceId(peer)
         i2osp(label),
+        oids
     )
+    // oids include AEAD, KDF, and HPKE algorithm OIDs for contextual binding
     (enc, ctx) = HPKE_SetupSend(
         mode=mode_auth,
         skS=sk(EncryptionKey(us)),   // our private key
@@ -110,12 +109,14 @@ fn NewChannelKeys(us, peer, parent_cmd_id, label) {
         info=info,
     )
 
-    SealKey = HPKE_ExportSecret(ctx, DeviceId(peer))
-    OpenKey = HPKE_ExportSecret(ctx, DeviceId(us))
+    SealKey = HPKE_ExportSecret(ctx, "bidi response key")
+    OpenKey = HPKE_ExportSecret(ctx, "bidi response key")
+    SealBaseNonce = HPKE_ExportSecret(ctx, "bidi response base_nonce")
+    OpenBaseNonce = HPKE_ExportSecret(ctx, "bidi response base_nonce")
 
     // `enc` is sent to the other device.
-    // `seal_key` and `open_key` are provided to AFC.
-    return (enc, (SealKey, OpenKey))
+    // Keys and base nonces are provided to AFC.
+    return (enc, (SealKey, OpenKey, SealBaseNonce, OpenBaseNonce))
 }
 
 // `parent_cmd_id` is the parent command ID.
@@ -124,17 +125,16 @@ fn DecryptChannelKeys(enc, us, peer, parent_cmd_id, label) {
         raise SameIdError
     }
 
-    suite_id = concat(aead_id, kdf_id, signer_id, ...)
     info = concat(
-        "AfcChannelKeys",
-        suite_id,
-        engine_id,
+        "AfcBidiKeys-v1",
         parent_cmd_id,
         // Note how these are swapped.
-        DeviceId(peer)
         DeviceId(us),
+        DeviceId(peer),
         i2osp(label),
+        oids
     )
+    // oids include AEAD, KDF, and HPKE algorithm OIDs for contextual binding
     ctx = HPKE_SetupRecv(
         mode=mode_auth,
         enc=enc,
@@ -144,10 +144,12 @@ fn DecryptChannelKeys(enc, us, peer, parent_cmd_id, label) {
     )
 
     // Remember, these are the reverse of `NewChannelKeys`.
-    SealKey = HPKE_ExportSecret(ctx, DeviceId(peer))
-    OpenKey = HPKE_ExportSecret(ctx, DeviceId(us))
+    SealKey = HPKE_ExportSecret(ctx, "bidi response key")
+    OpenKey = HPKE_ExportSecret(ctx, "bidi response key")
+    SealBaseNonce = HPKE_ExportSecret(ctx, "bidi response base_nonce")
+    OpenBaseNonce = HPKE_ExportSecret(ctx, "bidi response base_nonce")
 
-    return (seal_key, open_key)
+    return (SealKey, OpenKey, SealBaseNonce, OpenBaseNonce)
 }
 ```
 
@@ -184,16 +186,15 @@ fn NewSealOnlyKey(seal_id, open_id, parent_cmd_id, label) {
         raise SameIdError
     }
 
-    suite_id = concat(aead_id, kdf_id, signer_id, ...)
     info = concat(
-        "AfcUnidirectionalKey",
-        suite_id,
-        engine_id,
+        "AfcUniKey-v1",
         parent_cmd_id,
         seal_id,
         open_id,
         i2osp(label),
+        oids
     )
+    // oids include AEAD, KDF, and HPKE algorithm OIDs for contextual binding
     (enc, ctx) = HPKE_SetupSend(
         mode=mode_auth,
         skS=sk(EncryptionKey(us)),   // our private key
@@ -202,10 +203,11 @@ fn NewSealOnlyKey(seal_id, open_id, parent_cmd_id, label) {
     )
 
     SealOnlyKey = HPKE_ExportSecret(ctx, "unidirectional key")
+    SealBaseNonce = HPKE_ExportSecret(ctx, "unidirectional base_nonce")
 
     // `enc` is sent to the other device.
-    // `SealOnlyKey` is provided to AFC.
-    return (enc, SealOnlyKey)
+    // `SealOnlyKey` and base nonce are provided to AFC.
+    return (enc, SealOnlyKey, SealBaseNonce)
 }
 
 // `seal_id` is the device that is allowed to encrypt.
@@ -216,16 +218,15 @@ fn DecryptOpenOnlyKey(enc, us, peer, parent_cmd_id, label) {
         raise SameIdError
     }
 
-    suite_id = concat(aead_id, kdf_id, signer_id, ...)
     info = concat(
-        "AfcUnidirectionalKey",
-        suite_id,
-        engine_id,
+        "AfcUniKey-v1",
         parent_cmd_id,
         seal_id,
         open_id,
         i2osp(label),
+        oids
     )
+    // oids include AEAD, KDF, and HPKE algorithm OIDs for contextual binding
     ctx = HPKE_SetupRecv(
         mode=mode_auth,
         enc=enc,
@@ -234,7 +235,10 @@ fn DecryptOpenOnlyKey(enc, us, peer, parent_cmd_id, label) {
         info=info,
     )
 
-    return HPKE_ExportSecret(ctx, "unidirectional key")
+    OpenOnlyKey = HPKE_ExportSecret(ctx, "unidirectional key")
+    OpenBaseNonce = HPKE_ExportSecret(ctx, "unidirectional base_nonce")
+    
+    return (OpenOnlyKey, OpenBaseNonce)
 }
 ```
 
@@ -245,17 +249,16 @@ identical for both channel types.
 
 #### Message Encryption
 
-AFC encrypts each message with a uniformly random nonce generated
-by a CSPRNG.
+AFC encrypts each message with a deterministic nonce derived from a
+base nonce and sequence number.
 
 ```rust
-fn Seal(device, label, SealKey, plaintext) {
+fn Seal(device, label, SealKey, SealBaseNonce, sequence, plaintext) {
     header = concat(
         i2osp(version, 4), // version is a constant
-        i2osp(device, 4),
-        i2osp(label, 4),
+        i2osp(label, 4),   // device omitted from header
     )
-    nonce = random(AEAD_nonce_len())
+    nonce = xor(SealBaseNonce, i2osp(sequence, AEAD_nonce_len()))
     SealKey = FindSealKey(device, label)
     ciphertext = AEAD_Seal(
         key=SealKey,
@@ -263,18 +266,12 @@ fn Seal(device, label, SealKey, plaintext) {
         plaintext=plaintext,
         ad=header,
     )
-    // For performance reasons, the nonce and header are
-    // appended, instead of prepended.
-    return concat(ciphertext, nonce, header)
+    // Sequence number provides replay protection
+    return (ciphertext, sequence)
 }
 
-fn Open(device, label, ciphertext) {
-    // NB: while the header includes multiple fields, we only use
-    // the `label` since we already know everything else.
-    (ciphertext, nonce, header) = split(ciphertext);
-    (_, _, label) = split(header);
-
-    OpenKey = FindOpenKey(device, label)
+fn Open(device, OpenKey, OpenBaseNonce, ciphertext, sequence, header) {
+    nonce = xor(OpenBaseNonce, i2osp(sequence, AEAD_nonce_len()))
 
     plaintext = AEAD_Open(
         key=OpenKey,
@@ -282,7 +279,7 @@ fn Open(device, label, ciphertext) {
         ciphertext=ciphertext,
         ad=header,
     )
-    return plaintext
+    return (plaintext, label_from_header(header))
 }
 ```
 


### PR DESCRIPTION
## Summary

Updates the AFC cryptography specification to align with the actual implementation.

## Key Changes

- **Domain strings**: Updated to  and  (from /)
- **Key exports**: Use fixed strings like  instead of DeviceIDs
- **Base nonces**: Added separate base nonce derivation for deterministic nonce generation
- **Nonce method**: Changed from random nonces to sequence-based deterministic nonces
- **Associated data**: Removed device ID from header (only version and label remain)
- **OIDs**: Added cryptographic algorithm OIDs for contextual binding
- **Return values**: Updated to include base nonces in key derivation functions

## Verification

Changes reflect the actual cryptographic operations in:
- 
- 
- 

🤖 Generated with [Claude Code](https://claude.ai/code)