### PR TITLE
Afc related updates

### DIFF
--- a/docs/afc-crypto.md
+++ b/docs/afc-crypto.md
@@ -294,7 +294,7 @@ fn Open(channel_id, OpenKey, OpenBaseNonce, ciphertext) {
         ciphertext=ciphertext,
         ad=ad,
     )
-    return (plaintext, label_id)
+    return (plaintext, sequence, label_id)
 }
 ```
 

--- a/docs/afc.md
+++ b/docs/afc.md
@@ -83,7 +83,6 @@ when the daemon is restarted. See [aranya#483](https://github.com/aranya-project
 ## Aranya Fast Channel IDs
 
 Channels are locally identified by a `channel_id` which is a 32-bit integer. 
-The Aranya daemon generates channel IDs by incrementing a monotonic counter.
 
 This provides direct lookup without hash truncation.
 
@@ -105,8 +104,9 @@ Channel type is determined by the policy action used to create it.
 
 **Note: This is an overview of the relevant Public APIs for the aranya-fast-channels crate.
 
-- `add(channel_id, label_id, keys)` -
+- `add(label_id, keys) -> ChannelId` -
   Creates a new entry for a channel.
+  Returns the ID of the channel.
 - `remove(channel_id)` -
   Removes an existing channel
 - `seal(channel_id, ciphertext_buffer, plaintext) -> Header` -

--- a/docs/afc.md
+++ b/docs/afc.md
@@ -109,12 +109,12 @@ Channel type is determined by the policy action used to create it.
   Creates a new entry for a channel.
 - `remove(channel_id)` -
   Removes an existing channel
-- `seal(channel_id, label_id, ciphertext_buffer, plaintext) -> Header` -
+- `seal(channel_id, ciphertext_buffer, plaintext) -> Header` -
   Encrypts plaintext for the specified channel.
   Returns the header which includes channel metadata, like the AFC protocol version.
-- `open(channel_id, label_id, plaintext_buffer, ciphertext) -> sequence_number` -
-  Decrypts ciphertext from the peer. Returns the sequence number.
-  N.B. the `label_id` given as input is compared against the `label_id` associated with the channel.
+- `open(channel_id, plaintext_buffer, ciphertext) -> (label_id, sequence_number)` -
+  Decrypts ciphertext from the peer. 
+  Returns the label_id associated with the channel and the sequence number of the ciphertext.
 
 ### Policy
 

--- a/docs/aranya-mvp.md
+++ b/docs/aranya-mvp.md
@@ -332,7 +332,6 @@ pub struct AfcOpenChannel {
 - `CreateUniChannelSend(team_id, device_id, label_id) -> (AfcSendChannel, AfcCtrlMessage)` - create a unidirectional channel with the given peer device and label_id where the author is the sender.
 - `CreateUniChannelOpen(team_id, device_id, label_id) -> (AfcOpenChannel, AfcCtrlMessage)` - create a unidirectional channel with the given peer and label_id where the author is the opener.
 - `ReceiveCtrl(team_id, AfcCtrlMessage) -> AfcChannel` - creates an AFC channel by processing a 'ctrl' message.
-- `DeleteChannel(channel_id)` - Deletes an AFC channel. **Note**: This will remove the keys used for encryption/decryption.
 
 **Note**: The channel author must send `AfcCtrlMessage` to the peer via any transport. Once the peer receives `AfcCtrlMessage`, it should call `ReceiveCtrl()` to receive the other side of the channel.
 
@@ -364,6 +363,7 @@ Method on `AfcBidiChannel` and `AfcSendChannel`
 Methods on `AfcBidiChannel`, `AfcSendChannel` and `AfcOpenChannel`
 
 ```rust
+fn delete(&self) -> Result<(), Error>;
 fn channel_id(&self) -> AfcChannelId;
 fn label_id(&self) -> LabelId;
 ```

--- a/docs/aranya-mvp.md
+++ b/docs/aranya-mvp.md
@@ -332,6 +332,7 @@ pub struct AfcOpenChannel {
 - `CreateUniChannelSend(team_id, device_id, label_id) -> (AfcSendChannel, AfcCtrlMessage)` - create a unidirectional channel with the given peer device and label_id where the author is the sender.
 - `CreateUniChannelOpen(team_id, device_id, label_id) -> (AfcOpenChannel, AfcCtrlMessage)` - create a unidirectional channel with the given peer and label_id where the author is the opener.
 - `ReceiveCtrl(team_id, AfcCtrlMessage) -> AfcChannel` - creates an AFC channel by processing a 'ctrl' message.
+- `DeleteChannel(channel_id)` - Deletes an AFC channel. **Note**: This will remove the keys used for encryption/decryption.
 
 **Note**: The channel author must send `AfcCtrlMessage` to the peer via any transport. Once the peer receives `AfcCtrlMessage`, it should call `ReceiveCtrl()` to receive the other side of the channel.
 
@@ -363,7 +364,6 @@ Method on `AfcBidiChannel` and `AfcSendChannel`
 Methods on `AfcBidiChannel`, `AfcSendChannel` and `AfcOpenChannel`
 
 ```rust
-fn delete(&self) -> Result<(), Error>;
 fn channel_id(&self) -> AfcChannelId;
 fn label_id(&self) -> LabelId;
 ```


### PR DESCRIPTION
- Removes label_id param from the 'open' and 'seal' functions based on feedback in [this PR](https://github.com/aranya-project/aranya-core/pull/383#pullrequestreview-3231534617)
- AFC Client's add method returns a channel ID