### PR TITLE
docs: add post-release token validation step

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -174,7 +174,7 @@ Occasionally, release-related CI or workflow issues need to be fixed separately 
 ## Post-Release Checklist
 
 - **(manual)** Rotate the crates.io API key so it doesn't interfere with the next release. This reduces the risk of someone maliciously publishing crates with a compromised key. Rotation is performed by DevOps: generate a new token at [crates.io account settings](https://crates.io/settings/tokens), then update `ARANYA_BOT_CRATESIO_CARGO_LOGIN_KEY` in the GitHub environment secrets for both [aranya](https://github.com/aranya-project/aranya/settings/environments) and [aranya-core](https://github.com/aranya-project/aranya-core/settings/environments).
-- **(manual)** Verify the rotated crates.io token works in CI. Run `cargo owner --list aranya-buggy` in a CI workflow using the `ARANYA_BOT_CRATESIO_CARGO_LOGIN_KEY` secret. This authenticates with crates.io without publishing. Note: the `/api/v1/me` endpoint does not support API token authentication and cannot be used for this purpose.
+- **(manual)** Verify the rotated crates.io token works in CI. Run `cargo owner --list aranya-buggy` in a CI workflow using the `ARANYA_BOT_CRATESIO_CARGO_LOGIN_KEY` secret. This authenticates with crates.io without publishing. Note: the `/api/v1/me` endpoint does not support API token authentication and cannot be used for this purpose. See [this example PR](https://github.com/aranya-project/aranya/pull/782) for a reusable workflow.
 
 ## Patch Releases
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -174,6 +174,7 @@ Occasionally, release-related CI or workflow issues need to be fixed separately 
 ## Post-Release Checklist
 
 - **(manual)** Rotate the crates.io API key so it doesn't interfere with the next release. This reduces the risk of someone maliciously publishing crates with a compromised key. Rotation is performed by DevOps: generate a new token at [crates.io account settings](https://crates.io/settings/tokens), then update `ARANYA_BOT_CRATESIO_CARGO_LOGIN_KEY` in the GitHub environment secrets for both [aranya](https://github.com/aranya-project/aranya/settings/environments) and [aranya-core](https://github.com/aranya-project/aranya-core/settings/environments).
+- **(manual)** Verify the rotated crates.io token works in CI. Run `cargo owner --list aranya-buggy` in a CI workflow using the `ARANYA_BOT_CRATESIO_CARGO_LOGIN_KEY` secret. This authenticates with crates.io without publishing. Note: the `/api/v1/me` endpoint does not support API token authentication and cannot be used for this purpose.
 
 ## Patch Releases
 


### PR DESCRIPTION
## Summary

- Add a step to the Post-Release Checklist to verify the rotated crates.io token works in CI after rotation
- Documents using `cargo owner --list aranya-buggy` as the validation method, which authenticates with crates.io without publishing
- Notes that the `/api/v1/me` endpoint does not support API token auth

## Context

During the v6.0.0 release, the rotated crates.io token returned HTTP 403. Debugging revealed that the `/api/v1/me` endpoint rejects API tokens entirely. `cargo owner --list` is a reliable way to validate the token in CI without side effects.

See aranya-project/aranya#782 for a reusable CI workflow that runs this validation on a draft PR.

## Test plan

- [ ] Review the new checklist item in the Post-Release Checklist section