### PR TITLE
improve skiplist

### DIFF
--- a/docs/find-needed-segments-optimization.md
+++ b/docs/find-needed-segments-optimization.md
@@ -165,3 +165,47 @@ Each entry grows from 16 bytes (`Location`) to 24 bytes (`(Location, bool)` with
 **Segment max_cut ranges**: The `Segment` trait exposes `shortest_max_cut()` (first command) and `longest_max_cut()` (last command). Heads entries carry `longest_max_cut` (via prior Locations pointing to segment heads) and are popped highest first. Pending entries carry `shortest_max_cut` (via `first_location()`). The flush condition compares pending `shortest_max_cut` against the current head's `longest_max_cut`, ensuring correctness when ranges overlap.
 
 **Result ordering**: The result may need a final sort to ensure causal order (parents before children).
+
+## Skip List Optimization
+
+The single-pass traversal described above is O(n) per sync round where
+n is the number of segments between the head and the peer's known
+commands. When syncing a large graph across many rounds (each
+transferring SEGMENT_BUFFER_MAX segments), the total cost is O(n^2)
+because each round re-walks from the head.
+
+### Approach
+
+Before starting the main traversal, use skip lists to jump from the
+graph head to approximately `highest_have + SEGMENT_BUFFER_MAX`. This
+skips over the large uncovered region that won't fit in the current
+batch anyway (only SEGMENT_BUFFER_MAX segments are collected per
+round).
+
+The jump works as follows:
+
+1. Compute the target: `highest_have_max_cut + SEGMENT_BUFFER_MAX`,
+   where `highest_have` is the max cut of the peer's most recent known
+   command.
+2. Walk backwards from head using skip entries that stay at or above
+   the target. Do not follow any skip or prior that would go below the
+   target.
+3. Stop when no further step can be taken without going below the
+   target.
+4. Begin the normal traversal from that point instead of from head.
+
+This reduces the per-round cost from O(n) to O(log n + SEGMENT_BUFFER_MAX),
+making the total cost across all sync rounds O(n log n) instead of
+O(n^2).
+
+### Correctness
+
+The optimization is safe because:
+
+- Everything above the target is uncovered (no have_location has a
+  higher max cut than `highest_have`).
+- The normal traversal from the landing point will find the
+  SEGMENT_BUFFER_MAX lowest uncovered segments, which is the same set
+  the full traversal would collect.
+- Skip entries never jump into branches, so the landing point is
+  always an ancestor of the head on the same traversal path.

--- a/docs/skiplist.md
+++ b/docs/skiplist.md
@@ -72,6 +72,35 @@ Segment {
 
 ## Skip List Construction
 
+### Why Not Probabilistic
+
+The classical probabilistic skip list (Pugh 1990) assigns each element
+a random level and chains same-level elements together, halving span
+per level to reach O(log n) expected time. Two obstacles rule this out
+here:
+
+1. The O(log n) guarantee comes from the chain structure, not from
+   randomness alone. Independent uniform-random skips per segment --
+   without chains -- give expected search cost O(sqrt(N/k)) for k skips
+   per segment, because most random skips overshoot or land uselessly
+   for any given query. Matching O(log n) search requires k proportional
+   to N/log^2(N) per segment, nearly linear in N. An earlier version of
+   this design used three random skips per segment and exhibited this
+   behavior: for a target at distance 1000 in a graph of 50,000
+   segments, search visited roughly 200 segments instead of the
+   ~log2(1000) = 10 achievable with structured skips.
+
+2. Chains assume a sequence. A skip cannot jump into a branch (see
+   above), so same-level chains crossing merge points would require
+   per-branch tracking and LCA resolution -- most of the structural
+   work done below.
+
+The deterministic exponential spacing described in the following
+sections places log n entries per segment at distinct distance scales
+(N/2, 3N/4, 7N/8, ...), giving O(log n) worst-case search with log n
+pointers per segment. Each pointer is guaranteed useful at some
+distance rather than probabilistically so.
+
 ### Skip Targets
 
 For all segments, skip entries are placed at exponentially-spaced

--- a/docs/skiplist.md
+++ b/docs/skiplist.md
@@ -27,11 +27,7 @@ Where m is the average number of branches at a given max cut and n is the
 number of segments in the graph. Typically m should be less than 2.
 
 Each segment will have skips to segments further towards the root of the
-graph. A skip is a reference to a segment. When a segment is created we will
-randomly generate three different max cuts that are less than the new segment's
-max cut. The segment will then have skips to segments with matching max cuts.
-This will usually result in three skips, but it can be less if two different
-max cuts reference the same segment.
+graph. A skip is a reference to a segment.
 
 A skip can't jump into a branch. If this was allowed we'd have to backtrack
 to find missed branches. A skip can jump back to the last merge
@@ -74,45 +70,65 @@ Segment {
 },
 ```
 
-### Search algorithm
-Search will start at the head of the graph. If the max cut of the command is within
-the head segment that segment will be checked. If the command is found it will be
-returned. If the command is not found, the skip segment with lowest low_max_cut that is
->= to the command's max cut will be checked. If there is no skip segment to check
-the segments parent will be checked. If a merge command is reached both
-parent segments will be added to the list of heads. The algorithm will then be
-repeated with all of the added heads.
+## Skip List Construction
 
-This will result in quickly skipping deeply into the graph. When the search gets
-close and can no longer skip it'll fall back to checking segments and if a
-segment is reached whose low_max_cut is less than the commands max cut, then the
-search will back up and continue from a previous head.
+### Skip Targets
 
-```rust
-fn locate(id: Id, max_cut: usize) -> Some(Command) {
-    heads = [head.segment];
-    'outer: while let Some(head) = heads.pop() {
-        if head.high_max_cut < max_cut {
-            // we are too far back
-            continue;
-        }
-        if head.low_max_cut <= max_cut {
-            let command = head[max_cut - head.low_max_cut];
-            if command.id == id {
-                return Some(command);
-            }
-            continue;
-        }
-        // Assumes this is in ascending order
-        // Find the lowest skip that is not "below" the max_cut
-        for segment in head.skip_segments {
-            if segment.high_max_cut >= max_cut {
-                heads.push(segment);
-                continue 'outer;
-            }
-        }
-        heads.extend(head.parents());
-    }
-    None
-}
+For all segments, skip entries are placed at exponentially-spaced
+distances from the current max cut toward the root:
+
 ```
+N/2, 3N/4, 7N/8, 15N/16, ...
+```
+
+This continues until the gap between the current position and the next
+target is less than or equal to MIN_SKIP_GAP (10). For a segment at
+max cut N, this produces approximately log2(N/10) skip entries:
+
+```
+N = 100:    entries at 50, 75, 87, 93 (4 entries)
+N = 1000:   entries at 500, 750, 875, 937, 968, 984, 992 (7 entries)
+N = 10000:  entries at 5000, 7500, 8750, ... (10 entries)
+N = 1000000000: approximately 27 entries
+```
+
+### Merge Segments
+
+Merge segments use the same exponentially-spaced targets as non-merge
+segments, but the walk to find them starts from the least common
+ancestor (LCA) instead of the parent. Targets above the LCA's max cut
+are in a branch and naturally unreachable during the walk, so they
+are skipped. The LCA is always included in the skip list even if the
+sparse check (below) determines no other entries are needed.
+
+### Sparse Construction
+
+Not every segment needs a skip list. Before constructing one, check
+whether any ancestor within MIN_SKIP_GAP (10) segments already has a
+non-empty skip list. If so, skip construction entirely and write an
+empty skip list. Merge segments count as having a skip list since
+they always contain the LCA. For merge segments where the sparse check
+says no skip list is needed, the LCA is still included as the sole
+entry.
+
+This means approximately 1 in 10 segments builds a skip list. The other
+9 rely on a nearby ancestor's skip list, reachable within at most 10
+prior steps.
+
+### Finding Skip Targets
+
+Skip targets are found by walking backwards in a single pass. For
+non-merge segments the walk starts from the parent. For merge segments
+the walk starts from the LCA. The walk uses existing skip lists on
+intermediate segments to jump when possible:
+
+1. Compute all target max cuts (N/2, 3N/4, 7N/8, ...).
+2. Walk backwards from the start point, using skip entries that stay
+   at or above the lowest remaining target.
+3. As each target boundary is crossed, record the segment's first
+   location as a skip entry.
+4. Stop when all targets are collected.
+
+On a graph with well-formed skip lists, this walk takes O(log n) steps
+since intermediate segments have their own skip entries that allow
+jumping. The walk visits each segment at most once.


### PR DESCRIPTION
- Rework the skip list design in docs/skiplist.md from randomized skip targets to deterministic exponentially-spaced targets (N/2, 3N/4, 7N/8, ...), producing ~log2(N/10) entries per segment.
- Add sparse construction: only ~1 in 10 segments builds a skip list; others rely on a nearby ancestor's list within MIN_SKIP_GAP (10) steps.                                                                       
- Specify merge-segment handling: walks start from the LCA instead of the parent, and the LCA is always recorded as a skip entry.                                                                                  
- Describe the O(log n) backwards walk used to collect skip targets by reusing intermediate segments' skip lists.                                                                                                     
- Remove the old random-skip description and the locate search pseudocode (superseded by the new construction rules).                                                                                       
- Add a "Skip List Optimization" section to docs/find-needed-segments-optimization.md that uses the skip list to jump from head to highest_have_max_cut + SEGMENT_BUFFER_MAX before the main traversal, reducing total cost across sync rounds from O(n^2) to O(n log n).