### PR TITLE
Lazy merges spec

### DIFF
--- a/docs/lazy-merges.md
+++ b/docs/lazy-merges.md
@@ -105,6 +105,12 @@ update_head_set(cmd):
     head_set.retain(|h| !is_ancestor(h, cmd))
 ```
 
+### Merge ingestion
+
+A merge command carries only its parent addresses on the wire (`CommandMeta` in `sync/wire.rs`); the fact index is not transmitted, and a receiver has no way to verify a peer's fact index short of redoing the braid. So sync ingestion of a peer-authored merge braids the two parents locally and populates the merge segment's `FactIndex` from the result. This is the existing `add_merge` path in `Transaction::add_commands` (`crates/aranya-runtime/src/client/transaction.rs`) and is unchanged.
+
+In the lazy regime peers don't author merges during sync, so the merges on the wire are only those a peer wrote at commit time to collapse for a local action. Compared to eager — where every sync batch generates a peer-local merge that other peers then ingest — the merge volume drops sharply, which is what keeps the per-ingest braid cost affordable.
+
 ### Cache read and rebuild
 
 Every cache read goes through `read_cache`, which checks freshness and rebuilds if stale. Query, session, and author callers do not call a separate `ensure_cache_fresh`; they read the cache and the rebuild happens implicitly. Queries pass a `NullSink`; author and the public `refresh_cache` API thread the caller's sink so braid-fold effects flow out during rebuild.
@@ -138,7 +144,7 @@ Per-event costs:
 | Event | Cost |
 |:---|:---|
 | Sync ingest one command | O(1) head-set update plus per-segment write |
-| Sync ingest a merge command from a peer (both parents heads) | O(1) head-set update; no braid work |
+| Sync ingest a merge command from a peer | O(1) head-set update plus one braid over the two parents to populate the merge's fact index (see [Merge ingestion](#merge-ingestion)) |
 | Query, fresh cache | O(1) |
 | Query, stale cache | O(N + n) rebuild where N = head set size, n = commands since LCA |
 | Local author, fresh cache | (N-1) pairwise braids plus authored command write |

--- a/docs/lazy-merges.md
+++ b/docs/lazy-merges.md
@@ -37,9 +37,9 @@ Local authoring rebuilds the cache if stale, collapses the head set pairwise int
 
 ### Storage model
 
-The persisted graph state changes from `head: Location` to `heads: HeadSet`, where `HeadSet` is a small bounded vector of locations. The single-head case is a one-element head set.
+The persisted graph state changes from `head: Location` to `heads: HeadSet`, where `HeadSet` is a bounded vector of locations. The cap matches the braid's max-cut limit (256 concurrent authors); sync ingestion that would push the head set past capacity returns an error rather than forcing an inline merge — the same posture the braid takes today. The single-head case is a one-element head set.
 
-`Writer::head() -> Location` becomes `Writer::heads() -> HeadSet`. `Writer::commit(head: Location)` becomes `Writer::commit(heads: HeadSet, fact_cache: FactCacheRef)`.
+`Writer::head() -> Location` becomes `Writer::heads() -> HeadSet`. `Writer::commit(head: Location)` becomes `Writer::commit(heads: HeadSet, fact_cache: FactCacheRef)`; the fact cache is a separate persisted record (see [Fact Cache](#fact-cache)), and commit writes both atomically.
 
 ## Transaction Lifecycle
 
@@ -64,7 +64,9 @@ Init creates the graph and seeds `self.heads` with the init command directly; it
 
 ## Fact Cache
 
-The fact cache is a persisted record holding the merged fact perspective for some head set, separate from any merge segment. It contains:
+Today the merged perspective lives on the latest merge segment's fact index — every commit writes a merge, and that merge's `FactIndex` *is* the cache. Lazy merging removes the merge from the sync path, so the perspective has nowhere to live unless we give it a dedicated home.
+
+The fact cache is that home: a persisted record holding the merged fact perspective for some head set, separate from any merge segment. It contains:
 
 - A reference to the cached `FactIndex`.
 - The head set fingerprint at cache build time.
@@ -99,21 +101,8 @@ ingest(commands):
     // fact cache is left as-is; the next cache read rebuilds if stale
 
 update_head_set(cmd):
-    match cmd.parent():
-        Single(parent):
-            if parent in head_set:
-                replace parent with cmd in head_set
-            else:
-                add cmd to head_set
-                minimize head_set (remove ancestors)
-        Merge(left, right):
-            if {left, right} are both in head_set:
-                replace {left, right} with cmd in head_set
-            else:
-                add cmd to head_set
-                minimize head_set
-        None:
-            // init command; head set starts as {cmd}
+    head_set.insert(cmd)
+    head_set.retain(|h| !is_ancestor(h, cmd))
 ```
 
 ### Cache read and rebuild

--- a/docs/lazy-merges.md
+++ b/docs/lazy-merges.md
@@ -8,134 +8,54 @@ permalink: "/lazy-merges/"
 
 ## Overview
 
-Lazy merging defers writing merge commands until a local action requires a single parent. A graph carries a set of concurrent heads; sync extends the set without authoring merges. The merged fact perspective is held in a **fact cache** that is rebuilt lazily: sync updates the head set without folding policy, and the cache is rebuilt only when a query, session, or local author needs it. Sync bursts that aren't followed by a consumer event collapse into a single rebuild. Peers that have received the same authored commands have equal head sets regardless of arrival order, so cross-peer convergence completes in the rounds needed to propagate authored commands alone — no merge-of-merges cascade.
+Lazy merging changes two things:
+
+1. **Storage holds a head set and a fact cache** instead of a single head. The persisted `head: Location` becomes `heads: HeadSet`. A separate `FactCache` record holds the merged perspective for that head set so queries and sessions can read multi-head state at O(1).
+2. **`Transaction::commit` no longer collapses heads.** It writes `self.heads` to storage as-is, with a rebuilt fact cache. The pairwise-merge collapse moves to `action()`, where a new command actually needs a single parent.
+
+Everything else stays the same. `Transaction::add_commands` already accumulates a multi-head `self.heads` across multiple calls; the lifecycle API is unchanged. Orchestrators that hold a transaction open across multiple sync exchanges before committing get the most benefit, but the existing per-sync commit pattern still works.
 
 ## Problem
 
-`Transaction::commit` collapses every divergent head into a single graph head before returning, even in sync-only transactions. Each merge runs the braid algorithm over the divergent region between the existing graph head and the new commands.
-
-When P peers converge on N total commands, each peer ingests roughly N commands in batches from the other peers. Every batch triggers a braid whose region grows toward N as convergence progresses, and every braid writes a merge segment that subsequent syncs must walk through. Total work is O(P·N²).
-
-Profile of `generate_graph_hello_sync.test` (9 clients, 450 commands, no sync during generation, full convergence at end): ~2.5 million segment reads in the sync phase, close to the 9·450² = 1.82M lower bound.
-
-A related issue: peers that ingest the same authored commands in different orders produce structurally distinct merge commands. These merges then propagate, cascading into further merges before peers converge on the same state.
-
-Lazy merging targets both. Deferring the braid to consumer events and writing no merge segments during sync drops the work to O(P·N) — O(P·N) sync ingestion plus O(N) per-peer rebuild. On the profiled workload that's roughly 4,000 reads instead of 2.5M.
-
-## Key Insight
-
-The multi-head state has two persisted parts:
-
-- **Head set.** Concurrent locations representing the current state, replacing the single `head: Location`.
-- **Fact cache.** The merged fact perspective for some head set, persisted independently of any merge segment. The cache is *fresh* when its fingerprint matches the current head set; otherwise *stale*.
-
-Sync ingestion updates the head set and lets the cache go stale. The cache is rebuilt on demand when a query, session, or author event needs it.
-
-Local authoring rebuilds the cache if stale, collapses the head set pairwise into a single head, writes the merge segments with their own fact indexes, and writes the authored command on top. The cache seeds the final merge's fact index.
+`Transaction::commit` collapses every divergent head into a single graph head before returning, even in sync-only transactions. Every batch produces a merge segment that subsequent syncs walk through, and peers that ingest the same authored commands in different orders produce structurally distinct merge commands that themselves propagate — cascading into further merges before peers converge on the same state.
 
 ## Head Set
-
-### Storage model
 
 The persisted graph state changes from `head: Location` to `heads: HeadSet`, where `HeadSet` is a bounded vector of locations. The cap matches the braid's max-cut limit (256 concurrent authors); sync ingestion that would push the head set past capacity returns an error rather than forcing an inline merge — the same posture the braid takes today. The single-head case is a one-element head set.
 
 `Writer::head() -> Location` becomes `Writer::heads() -> HeadSet`. `Writer::commit(head: Location)` becomes `Writer::commit(heads: HeadSet, fact_cache: FactCacheRef)`; the fact cache is a separate persisted record (see [Fact Cache](#fact-cache)), and commit writes both atomically.
 
-## Transaction Lifecycle
-
-`Transaction` carries `self.heads: BTreeMap<CmdId, Location>`. Today it tracks only commands written during the transaction and is pairwise-merged at commit. Under lazy merging, `self.heads` is seeded with the graph's head set at transaction start and mutated as commands arrive.
-
-Ingestion updates `self.heads` in place:
-
-- `Single(parent)`: replace `parent` if it was a head, otherwise add the new command.
-- `Merge(left, right)`: add the merge; remove whichever of `left` and `right` were heads.
-
-### Commit
-
-Commit persists `self.heads` and the updated fact cache. If the transaction authors a local `Single(parent)` action — which needs a single parent — `self.heads` must first be collapsed to a single head:
-
-1. Write any in-flight perspective to storage, registering its head in `self.heads`.
-2. If `self.heads` has more than one member, run the existing pairwise merge loop in `Transaction::commit`. Each merge writes a segment with its own fact index.
-3. Write the authored command on top of the single resulting head; `self.heads` becomes `{authored command}`.
-
-The final merge's fact index is the cached perspective for the pre-collapse head set. Intermediate merges compute their fact indexes via `make_braid_segment` as today.
-
-Init creates the graph and seeds `self.heads` with the init command directly; it bypasses this lifecycle.
-
 ## Fact Cache
 
-Today the merged perspective lives on the latest merge segment's fact index — every commit writes a merge, and that merge's `FactIndex` *is* the cache. Lazy merging removes the merge from the sync path, so the perspective has nowhere to live unless we give it a dedicated home.
+Today the merged perspective lives on the latest merge segment's fact index — every commit writes a merge, and that merge's `FactIndex` *is* the cache. Lazy merging removes the merge from the sync-only path, so the perspective has nowhere to live unless we give it a dedicated home.
 
-The fact cache is that home: a persisted record holding the merged fact perspective for some head set, separate from any merge segment. It contains:
+The fact cache is that home: a persisted record holding the merged fact perspective for the current head set. It contains a reference to a `FactIndex`. The cache is always the merged perspective at the last committed head set, by invariant — commit is its only writer.
 
-- A reference to the cached `FactIndex`.
-- The head set fingerprint at cache build time.
+Commit is the only writer: every commit recomputes the merged perspective for the current head set (n-way braid + `call_rule` per command in braid order) and persists the result. Queries and sessions read the cache directly. Between commits, the cache reflects the last-committed state; in-flight transactional state is not visible — same isolation as today, just over whatever span the caller keeps the transaction open.
 
-The cache is *fresh* when its fingerprint matches the current head set and *stale* otherwise.
+## Commit
 
-### Update strategy
-
-Sync ingestion does not fold policy. It updates the head set and the fact cache is left untouched — it becomes stale. Sync bursts pay only O(1) per command plus the per-segment storage writes.
-
-The cache is rebuilt when one of these events needs the merged perspective:
-
-- An explicit `refresh_cache` call from the application. This is the expected mechanism for downstream effect listeners: the application schedules `refresh_cache` on its own cadence, and the rebuild's `call_rule` invocations emit braid-fold effects to the sink.
-- A fact query.
-- `Session::new` reading the perspective.
-- A local author, which needs the cache to seed the final merge's fact index.
-
-Multiple sync events that arrive between consumer events collapse into a single rebuild.
-
-## Algorithm
-
-### Sync ingestion
+Commit writes `self.heads` to storage and rebuilds the fact cache for that head set. The pairwise-merge collapse that today's commit performs is gone.
 
 ```
-ingest(commands):
-    for each command in commands:
-        if command is already present in storage:
-            continue
-        write command to storage  // creates segment, updates per-segment fact index
-        update_head_set(command)
-    persist head_set
-    // fact cache is left as-is; the next cache read rebuilds if stale
-
-update_head_set(cmd):
-    head_set.insert(cmd)
-    head_set.retain(|h| !is_ancestor(h, cmd))
+commit(sink):
+    persist any in-flight perspective into self.heads
+    perspective = braid_n_way(self.heads)
+    for each command in braid_order(self.heads):
+        call_rule(command, perspective, sink)  // emits braid-fold effects
+    fact_cache = write_facts(perspective)
+    storage.commit(self.heads, fact_cache)
 ```
 
-### Merge ingestion
+The `call_rule` invocations during the cache rebuild are where the application sees effects for the accumulated sync work.
 
-A merge command carries only its parent addresses on the wire (`CommandMeta` in `sync/wire.rs`); the fact index is not transmitted, and a receiver has no way to verify a peer's fact index short of redoing the braid. So sync ingestion of a peer-authored merge braids the two parents locally and populates the merge segment's `FactIndex` from the result. This is the existing `add_merge` path in `Transaction::add_commands` (`crates/aranya-runtime/src/client/transaction.rs`) and is unchanged.
+Init creates the graph and seeds storage with the init command directly; it bypasses this flow.
 
-In the lazy regime peers don't author merges during sync, so the merges on the wire are only those a peer wrote at commit time to collapse for a local action. Compared to eager — where every sync batch generates a peer-local merge that other peers then ingest — the merge volume drops sharply, which is what keeps the per-ingest braid cost affordable.
+## Action
 
-### Cache read and rebuild
+A new command needs a single parent. `action()` reads `storage.get_heads()`, runs the pairwise-merge loop to collapse the head set to a single head (writing merge segments along the way), gets a linear perspective at the resulting single head, calls the policy's action handler to generate and apply the new command, and commits. The post-action head set is a one-element set.
 
-Every cache read goes through `read_cache`, which checks freshness and rebuilds if stale. Query, session, and author callers do not call a separate `ensure_cache_fresh`; they read the cache and the rebuild happens implicitly. Queries pass a `NullSink`; author and the public `refresh_cache` API thread the caller's sink so braid-fold effects flow out during rebuild.
-
-```
-read_cache(sink) -> FactPerspective:
-    if fact_cache.fingerprint != fingerprint(head_set):
-        rebuild_cache(sink)
-    return fact_cache.perspective
-
-rebuild_cache(sink):
-    lca = n_way_lca(head_set)
-    order = braid_n_way(head_set, lca)
-    first = order.iter().next()
-    perspective = storage.get_fact_perspective(first)
-    for loc in order.iter().skip(1):
-        cmd = command_at(loc)
-        call_rule(cmd, &mut perspective, sink)
-    fact_cache.perspective = write_facts(perspective)
-    fact_cache.fingerprint = fingerprint(head_set)
-
-refresh_cache(sink):
-    // Public API. Forces rebuild if stale; emits braid-fold effects.
-    read_cache(sink)
-```
+The pairwise-merge loop that lives in `Transaction::commit` today moves to `action()` — same logic, the path it belongs on.
 
 ## Complexity
 
@@ -143,29 +63,23 @@ Per-event costs:
 
 | Event | Cost |
 |:---|:---|
-| Sync ingest one command | O(1) head-set update plus per-segment write |
-| Sync ingest a merge command from a peer | O(1) head-set update plus one braid over the two parents to populate the merge's fact index (see [Merge ingestion](#merge-ingestion)) |
-| Query, fresh cache | O(1) |
-| Query, stale cache | O(N + n) rebuild where N = head set size, n = commands since LCA |
-| Local author, fresh cache | (N-1) pairwise braids plus authored command write |
-| Local author, stale cache | rebuild plus (N-1) pairwise braids plus authored command write |
+| Sync ingest one Single command | O(1) head-set update plus per-segment write (unchanged from today) |
+| Sync ingest a peer-authored merge | O(1) head-set update plus one braid over the two parents (unchanged — see [note](#note-on-merge-ingestion)) |
+| Commit (sync-only) | O(N + n) cache rebuild where N = head set size, n = commands since LCA |
+| Action | (N-1) pairwise braids to collapse, plus the new command's write |
+| Query | O(1) — reads the fact cache directly |
 
 Compared to eager:
 
-- **Cross-peer convergence.** Eager generates peer-specific merges that must themselves propagate, cascading into further merges. Lazy authors no merges during sync, so peers with the same authored commands have equal head sets. Convergence completes in the rounds needed to propagate authored commands alone.
-- **Many syncs, no local consumer in between.** Eager pays a full braid per sync event and writes a merge segment for each. Lazy pays O(1) per sync; a single rebuild at the next consumer event amortizes the braid work across the entire burst.
-- **Many syncs, frequent queries.** Each query that finds the cache stale triggers a rebuild. In the worst case (one query per sync) lazy and eager do equivalent braid work; lazy still saves merge segment writes and convergence rounds.
+- **Cross-peer convergence.** Eager generates peer-specific merges during sync that must themselves propagate, cascading into further merges. Lazy authors no merges during sync, so peers with the same authored commands have equal head sets. Convergence completes in the rounds needed to propagate authored commands alone.
+- **Many syncs per round.** Eager pays a full pairwise-merge collapse on every per-sync commit. A caller that holds the transaction open across multiple sync exchanges pays one cache rebuild at the eventual commit and writes no merge segments. The merge segments that subsequent syncs walked through under eager are gone.
 - **One sync, immediate author.** Same braid work either way.
 
 ## Edge Cases
 
 ### Concurrency
 
-Single-writer is a property of the runtime: `ClientState` requires `&mut self` for all graph operations, and the storage backend contractually requires a single writer per file (see the comment at the top of `storage/linear/io.rs`). The lazy-merges design doesn't change that.
-
-### Sessions
-
-`Session::new` reads the fact cache (rebuilding if stale) to seed the session perspective instead of using `storage.get_head()`. Session commit follows the same author-time collapse rules as the main client.
+Single-writer is a property of the runtime: `ClientState` requires `&mut self` for all graph operations, and the storage backend contractually requires a single writer per file. The lazy-merges design doesn't change that.
 
 ## Changes
 
@@ -176,12 +90,16 @@ Single-writer is a property of the runtime: `ClientState` requires `&mut self` f
 - On-disk format extends to carry the head set and fact cache. Existing single-head graphs read as one-element head sets.
 - `Storage::get_head()` becomes `Storage::get_heads()`.
 - New `fact_cache` accessor returns the cached `FactIndex`.
+- New persisted record: `FactCache { fact_index: FactIndexRef }`.
 
 ### Transaction
 
-- `self.heads` is seeded with `storage.get_heads()?` on first use instead of being empty.
-- Ingestion mutates `self.heads` in place; commit persists it directly when no authoring occurred.
-- The pairwise merge loop in `Transaction::commit` runs only on the authoring path and seeds the final merge's fact index from the cache.
+- `Transaction::commit` no longer collapses heads. It rebuilds the fact cache n-way (emitting effects to the caller's sink) and persists the head set and cache.
+
+### Action
+
+- `ClientState::action` reads `storage.get_heads()` instead of `storage.get_head()`.
+- The pairwise-merge collapse loop moves from `Transaction::commit` to `action()`. It produces a single head before the policy's action handler runs.
 
 ### Sync
 
@@ -194,12 +112,6 @@ Single-writer is a property of the runtime: `ClientState` requires `&mut self` f
 - `last_common_ancestor` takes a slice and computes the N-way LCA.
 - `ConvergenceMap::new` takes a slice of heads.
 
-### Fact cache
-
-- New persisted record: `FactCache { fact_index: FactIndexRef, fingerprint: Hash }`.
-- New module for `read_cache`, `rebuild_cache`, `query`. Every cache read goes through `read_cache`, which rebuilds implicitly if stale.
-- New public `ClientState::refresh_cache(graph_id, sink)` method. Callers use it to drive periodic rebuild and to receive braid-fold effects on their own schedule, decoupled from query and author paths.
-
 ### Session
 
-- `Session::new` seeds from the fact cache.
+- `Session::new` seeds `base_facts` from the fact cache instead of the head segment.

--- a/docs/lazy-merges.md
+++ b/docs/lazy-merges.md
@@ -1,0 +1,211 @@
+---
+layout: page
+title: Lazy Merges
+permalink: "/lazy-merges/"
+---
+
+# Lazy Merges
+
+## Overview
+
+Lazy merging defers writing merge commands until a local action requires a single parent. A graph carries a set of concurrent heads; sync extends the set without authoring merges. The merged fact perspective is held in a **fact cache** that is rebuilt lazily: sync updates the head set without folding policy, and the cache is rebuilt only when a query, session, or local author needs it. Sync bursts that aren't followed by a consumer event collapse into a single rebuild. Peers that have received the same authored commands have equal head sets regardless of arrival order, so cross-peer convergence completes in the rounds needed to propagate authored commands alone — no merge-of-merges cascade.
+
+## Problem
+
+`Transaction::commit` collapses every divergent head into a single graph head before returning, even in sync-only transactions. Each merge runs the braid algorithm over the divergent region between the existing graph head and the new commands.
+
+When P peers converge on N total commands, each peer ingests roughly N commands in batches from the other peers. Every batch triggers a braid whose region grows toward N as convergence progresses, and every braid writes a merge segment that subsequent syncs must walk through. Total work is O(P·N²).
+
+Profile of `generate_graph_hello_sync.test` (9 clients, 450 commands, no sync during generation, full convergence at end): ~2.5 million segment reads in the sync phase, close to the 9·450² = 1.82M lower bound.
+
+A related issue: peers that ingest the same authored commands in different orders produce structurally distinct merge commands. These merges then propagate, cascading into further merges before peers converge on the same state.
+
+Lazy merging targets both. Deferring the braid to consumer events and writing no merge segments during sync drops the work to O(P·N) — O(P·N) sync ingestion plus O(N) per-peer rebuild. On the profiled workload that's roughly 4,000 reads instead of 2.5M.
+
+## Key Insight
+
+The multi-head state has two persisted parts:
+
+- **Head set.** Concurrent locations representing the current state, replacing the single `head: Location`.
+- **Fact cache.** The merged fact perspective for some head set, persisted independently of any merge segment. The cache is *fresh* when its fingerprint matches the current head set; otherwise *stale*.
+
+Sync ingestion updates the head set and lets the cache go stale. The cache is rebuilt on demand when a query, session, or author event needs it.
+
+Local authoring rebuilds the cache if stale, collapses the head set pairwise into a single head, writes the merge segments with their own fact indexes, and writes the authored command on top. The cache seeds the final merge's fact index.
+
+## Head Set
+
+### Storage model
+
+The persisted graph state changes from `head: Location` to `heads: HeadSet`, where `HeadSet` is a small bounded vector of locations. The single-head case is a one-element head set.
+
+`Writer::head() -> Location` becomes `Writer::heads() -> HeadSet`. `Writer::commit(head: Location)` becomes `Writer::commit(heads: HeadSet, fact_cache: FactCacheRef)`.
+
+## Transaction Lifecycle
+
+`Transaction` carries `self.heads: BTreeMap<CmdId, Location>`. Today it tracks only commands written during the transaction and is pairwise-merged at commit. Under lazy merging, `self.heads` is seeded with the graph's head set at transaction start and mutated as commands arrive. The single `original_head` snapshot becomes `original_heads`, used only for concurrency detection.
+
+Ingestion updates `self.heads` in place:
+
+- `Single(parent)`: replace `parent` if it was a head, otherwise add the new command.
+- `Merge(left, right)`: add the merge; remove whichever of `left` and `right` were heads.
+
+### Commit
+
+Commit persists `self.heads` and the updated fact cache. If the transaction authors a local `Single(parent)` action — which needs a single parent — `self.heads` must first be collapsed to a single head:
+
+1. Write any in-flight perspective to storage, registering its head in `self.heads`.
+2. If `self.heads` has more than one member, run the existing pairwise merge loop in `Transaction::commit`. Each merge writes a segment with its own fact index.
+3. Write the authored command on top of the single resulting head; `self.heads` becomes `{authored command}`.
+
+The final merge's fact index is the cached perspective for the pre-collapse head set. Intermediate merges compute their fact indexes via `make_braid_segment` as today.
+
+Init creates the graph and seeds `self.heads` with the init command directly; it bypasses this lifecycle.
+
+## Fact Cache
+
+The fact cache is a persisted record holding the merged fact perspective for some head set, separate from any merge segment. It contains:
+
+- A reference to the cached `FactIndex`.
+- The head set fingerprint at cache build time.
+
+The cache is *fresh* when its fingerprint matches the current head set and *stale* otherwise.
+
+### Update strategy
+
+Sync ingestion does not fold policy. It updates the head set and the fact cache is left untouched — it becomes stale. Sync bursts pay only O(1) per command plus the per-segment storage writes.
+
+The cache is rebuilt when one of these events needs the merged perspective:
+
+- An explicit `refresh_cache` call from the application. This is the expected mechanism for downstream effect listeners: the application schedules `refresh_cache` on its own cadence, and the rebuild's `call_rule` invocations emit braid-fold effects to the sink.
+- A fact query.
+- `Session::new` reading the perspective.
+- A local author, which needs the cache to seed the final merge's fact index.
+
+Multiple sync events that arrive between consumer events collapse into a single rebuild.
+
+## Algorithm
+
+### Sync ingestion
+
+```
+ingest(commands):
+    for each command in commands:
+        if command is already present in storage:
+            continue
+        write command to storage  // creates segment, updates per-segment fact index
+        update_head_set(command)
+    persist head_set
+    // fact cache is left as-is; the next cache read rebuilds if stale
+
+update_head_set(cmd):
+    match cmd.parent():
+        Single(parent):
+            if parent in head_set:
+                replace parent with cmd in head_set
+            else:
+                add cmd to head_set
+                minimize head_set (remove ancestors)
+        Merge(left, right):
+            if {left, right} are both in head_set:
+                replace {left, right} with cmd in head_set
+            else:
+                add cmd to head_set
+                minimize head_set
+        None:
+            // init command; head set starts as {cmd}
+```
+
+### Cache read and rebuild
+
+Every cache read goes through `read_cache`, which checks freshness and rebuilds if stale. Query, session, and author callers do not call a separate `ensure_cache_fresh`; they read the cache and the rebuild happens implicitly. Queries pass a `NullSink`; author and the public `refresh_cache` API thread the caller's sink so braid-fold effects flow out during rebuild.
+
+```
+read_cache(sink) -> FactPerspective:
+    if fact_cache.fingerprint != fingerprint(head_set):
+        rebuild_cache(sink)
+    return fact_cache.perspective
+
+rebuild_cache(sink):
+    lca = n_way_lca(head_set)
+    order = braid_n_way(head_set, lca)
+    first = order.iter().next()
+    perspective = storage.get_fact_perspective(first)
+    for loc in order.iter().skip(1):
+        cmd = command_at(loc)
+        call_rule(cmd, &mut perspective, sink)
+    fact_cache.perspective = write_facts(perspective)
+    fact_cache.fingerprint = fingerprint(head_set)
+
+refresh_cache(sink):
+    // Public API. Forces rebuild if stale; emits braid-fold effects.
+    read_cache(sink)
+```
+
+## Complexity
+
+Per-event costs:
+
+| Event | Cost |
+|:---|:---|
+| Sync ingest one command | O(1) head-set update plus per-segment write |
+| Sync ingest a merge command from a peer (both parents heads) | O(1) head-set update; no braid work |
+| Query, fresh cache | O(1) |
+| Query, stale cache | O(N + n) rebuild where N = head set size, n = commands since LCA |
+| Local author, fresh cache | (N-1) pairwise braids plus authored command write |
+| Local author, stale cache | rebuild plus (N-1) pairwise braids plus authored command write |
+
+Compared to eager:
+
+- **Cross-peer convergence.** Eager generates peer-specific merges that must themselves propagate, cascading into further merges. Lazy authors no merges during sync, so peers with the same authored commands have equal head sets. Convergence completes in the rounds needed to propagate authored commands alone.
+- **Many syncs, no local consumer in between.** Eager pays a full braid per sync event and writes a merge segment for each. Lazy pays O(1) per sync; a single rebuild at the next consumer event amortizes the braid work across the entire burst.
+- **Many syncs, frequent queries.** Each query that finds the cache stale triggers a rebuild. In the worst case (one query per sync) lazy and eager do equivalent braid work; lazy still saves merge segment writes and convergence rounds.
+- **One sync, immediate author.** Same braid work either way.
+
+## Edge Cases
+
+### Concurrent transactions
+
+`Transaction::commit` errors with `ClientError::ConcurrentTransaction` when `original_head != storage.get_head()`. In the head-set model the check becomes: every member of `original_heads` must still be present in the current head set or covered by a descendant. Elements removed without a descendant subsuming them reject the transaction.
+
+### Sessions
+
+`Session::new` reads the fact cache (rebuilding if stale) to seed the session perspective instead of using `storage.get_head()`. Session commit follows the same author-time collapse rules as the main client.
+
+## Changes
+
+### Storage layer
+
+- `Writer::head() -> Location` becomes `Writer::heads() -> HeadSet`.
+- `Writer::commit(head: Location)` becomes `Writer::commit(heads: HeadSet, fact_cache: FactCache)`.
+- On-disk format extends to carry the head set and fact cache. Existing single-head graphs read as one-element head sets.
+- `Storage::get_head()` becomes `Storage::get_heads()`.
+- New `fact_cache` accessor returns the cached `FactIndex`.
+
+### Transaction
+
+- `Transaction::original_head: Option<Location>` becomes `original_heads: Option<HeadSet>`.
+- `self.heads` is seeded with `storage.get_heads()?` on first use instead of being empty.
+- Ingestion mutates `self.heads` in place; commit persists it directly when no authoring occurred.
+- The pairwise merge loop in `Transaction::commit` runs only on the authoring path and seeds the final merge's fact index from the cache.
+
+### Sync
+
+- `SyncRequester::get_commands` walks back from each head in the head set instead of `storage.get_head()`. Wire format unchanged.
+- `SyncResponder` and `PeerCache` are unchanged.
+
+### Braid
+
+- `braid` takes a slice of heads.
+- `last_common_ancestor` takes a slice and computes the N-way LCA.
+- `ConvergenceMap::new` takes a slice of heads.
+
+### Fact cache
+
+- New persisted record: `FactCache { fact_index: FactIndexRef, fingerprint: Hash }`.
+- New module for `read_cache`, `rebuild_cache`, `query`. Every cache read goes through `read_cache`, which rebuilds implicitly if stale.
+- New public `ClientState::refresh_cache(graph_id, sink)` method. Callers use it to drive periodic rebuild and to receive braid-fold effects on their own schedule, decoupled from query and author paths.
+
+### Session
+
+- `Session::new` seeds from the fact cache.

--- a/docs/lazy-merges.md
+++ b/docs/lazy-merges.md
@@ -43,7 +43,7 @@ The persisted graph state changes from `head: Location` to `heads: HeadSet`, whe
 
 ## Transaction Lifecycle
 
-`Transaction` carries `self.heads: BTreeMap<CmdId, Location>`. Today it tracks only commands written during the transaction and is pairwise-merged at commit. Under lazy merging, `self.heads` is seeded with the graph's head set at transaction start and mutated as commands arrive. The single `original_head` snapshot becomes `original_heads`, used only for concurrency detection.
+`Transaction` carries `self.heads: BTreeMap<CmdId, Location>`. Today it tracks only commands written during the transaction and is pairwise-merged at commit. Under lazy merging, `self.heads` is seeded with the graph's head set at transaction start and mutated as commands arrive.
 
 Ingestion updates `self.heads` in place:
 
@@ -159,9 +159,9 @@ Compared to eager:
 
 ## Edge Cases
 
-### Concurrent transactions
+### Concurrency
 
-`Transaction::commit` errors with `ClientError::ConcurrentTransaction` when `original_head != storage.get_head()`. In the head-set model the check becomes: every member of `original_heads` must still be present in the current head set or covered by a descendant. Elements removed without a descendant subsuming them reject the transaction.
+Single-writer is a property of the runtime: `ClientState` requires `&mut self` for all graph operations, and the storage backend contractually requires a single writer per file (see the comment at the top of `storage/linear/io.rs`). The lazy-merges design doesn't change that.
 
 ### Sessions
 
@@ -179,7 +179,6 @@ Compared to eager:
 
 ### Transaction
 
-- `Transaction::original_head: Option<Location>` becomes `original_heads: Option<HeadSet>`.
 - `self.heads` is seeded with `storage.get_heads()?` on first use instead of being empty.
 - Ingestion mutates `self.heads` in place; commit persists it directly when no authoring occurred.
 - The pairwise merge loop in `Transaction::commit` runs only on the authoring path and seeds the final merge's fact index from the cache.


### PR DESCRIPTION
Spec for a multi-head storage model that defers merge authoring to local action time and rebuilds a fact cache lazily at consumer events, dropping multi-peer convergence from O(P*N^2) to O(P*N).